### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/main.py
+++ b/main.py
@@ -209,7 +209,7 @@ async def calculate_leave(request: LeaveCalculationRequest):
     except ValueError as e:
         logger.warning(f"Validation error: {str(e)}")
         return JSONResponse(
-            status_code=400, content={"success": False, "error": str(e)}
+            status_code=400, content={"success": False, "error": "Invalid input data"}
         )
     except Exception as e:
         logger.error(f"Unexpected error: {str(e)}")


### PR DESCRIPTION
Potential fix for [https://github.com/MattKobayashi/leave-calculator/security/code-scanning/1](https://github.com/MattKobayashi/leave-calculator/security/code-scanning/1)

To fix the problem, we should avoid returning the raw exception message (`str(e)`) to the user in the API response. Instead, we should return a generic, user-friendly error message for validation errors, while logging the actual exception message on the server for debugging purposes. This ensures that sensitive or internal information is not exposed to the client, but developers can still access the details in the logs.

**How to fix:**
- In the `except ValueError as e` block (lines 209–213), replace the use of `str(e)` in the response with a generic message such as "Invalid input data".
- Continue to log the actual exception message using `logger.warning`.
- No changes are needed to the logging configuration or other exception handling.

**Required changes:**
- Edit lines 212–213 in `main.py` to return a generic error message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
